### PR TITLE
feat: Add monthly spending report modal with popup interface

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -94,6 +94,139 @@ body {
   margin-bottom: 0.5rem;
 }
 
+/* Monthly Report Card */
+.monthly-report-card {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-lg);
+  margin-bottom: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.report-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.report-header h3 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.report-subtitle {
+  opacity: 0.9;
+  font-size: 1rem;
+}
+
+.report-content {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 1rem;
+  backdrop-filter: blur(10px);
+}
+
+.report-category {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  transition: background-color 0.2s ease;
+}
+
+.report-category:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.report-category:last-child {
+  border-bottom: none;
+}
+
+.category-emoji {
+  font-size: 1.5rem;
+  min-width: 40px;
+  text-align: center;
+}
+
+.category-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.category-name {
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.category-amount {
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: #fbbf24;
+}
+
+.category-change {
+  font-weight: 700;
+  font-size: 1.1rem;
+  min-width: 80px;
+  text-align: right;
+}
+
+.category-change.text-success {
+  color: #10b981;
+}
+
+.category-change.text-danger {
+  color: #ef4444;
+}
+
+.category-change.text-muted {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.report-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0.75rem;
+  margin-top: 1rem;
+  border-top: 2px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+}
+
+.summary-total {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.summary-change {
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.summary-change.text-success {
+  color: #10b981;
+}
+
+.summary-change.text-danger {
+  color: #ef4444;
+}
+
+.summary-change.text-muted {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.no-data-message {
+  text-align: center;
+  padding: 2rem;
+  opacity: 0.8;
+}
+
 /* Category Overview */
 .category-overview {
   background: var(--card-background);
@@ -214,6 +347,7 @@ body {
 .btn-secondary:hover {
   background-color: #475569;
   transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
 }
 
 .btn-danger {
@@ -224,6 +358,7 @@ body {
 .btn-danger:hover {
   background-color: #dc2626;
   transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
 }
 
 .btn-success {
@@ -234,6 +369,7 @@ body {
 .btn-success:hover {
   background-color: #059669;
   transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
 }
 
 /* Expense List */
@@ -696,5 +832,217 @@ textarea {
   .receipt-table select {
     font-size: 0.9rem;
     padding: 0.4rem;
+  }
+}
+
+/* Monthly Report Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  backdrop-filter: blur(5px);
+  animation: fadeIn 0.3s ease-out;
+}
+
+.modal-content {
+  background: var(--card-background);
+  border-radius: 16px;
+  box-shadow: var(--shadow-lg);
+  max-width: 600px;
+  width: 90%;
+  max-height: 80vh;
+  overflow: hidden;
+  animation: slideIn 0.3s ease-out;
+}
+
+.modal-header {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modal-header h3 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  color: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 8px;
+  transition: background-color 0.2s ease;
+  font-size: 0.9rem;
+}
+
+.modal-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.close-icon {
+  font-size: 1.5rem;
+  font-weight: bold;
+  line-height: 1;
+}
+
+.close-text {
+  font-weight: 500;
+}
+
+.modal-body {
+  padding: 1.5rem;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.report-categories {
+  margin-bottom: 1.5rem;
+}
+
+.report-category-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-color);
+  transition: background-color 0.2s ease;
+}
+
+.report-category-item:hover {
+  background: var(--background-color);
+}
+
+.report-category-item:last-child {
+  border-bottom: none;
+}
+
+.report-category-item .category-emoji {
+  font-size: 1.25rem;
+  min-width: 30px;
+}
+
+.report-category-item .category-name {
+  font-weight: 600;
+  flex: 1;
+  color: var(--text-primary);
+}
+
+.report-category-item .category-amount {
+  font-weight: 700;
+  color: var(--primary-color);
+  margin-right: 0.5rem;
+}
+
+.report-category-item .category-change {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.report-category-item .category-change.text-success {
+  color: var(--success-color);
+}
+
+.report-category-item .category-change.text-danger {
+  color: var(--danger-color);
+}
+
+.report-category-item .category-change.text-muted {
+  color: var(--text-secondary);
+}
+
+.report-summary {
+  background: var(--background-color);
+  border-radius: 12px;
+  padding: 1.5rem;
+  border: 2px solid var(--border-color);
+}
+
+.summary-total {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 1.25rem;
+}
+
+.summary-total strong {
+  color: var(--text-primary);
+}
+
+.summary-change {
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.summary-change.text-success {
+  color: var(--success-color);
+}
+
+.summary-change.text-danger {
+  color: var(--danger-color);
+}
+
+.summary-change.text-muted {
+  color: var(--text-secondary);
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 768px) {
+  .modal-content {
+    width: 95%;
+    max-height: 90vh;
+  }
+  
+  .modal-header {
+    padding: 1rem;
+  }
+  
+  .modal-header h3 {
+    font-size: 1.25rem;
+  }
+  
+  .modal-body {
+    padding: 1rem;
+  }
+  
+  .report-category-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+  
+  .report-category-item .category-amount {
+    margin-right: 0;
+  }
+  
+  .summary-total {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
   }
 }

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -1,10 +1,25 @@
 require "ostruct"
+require_relative "../services/first_visit_detector_service"
+require_relative "../services/monthly_spending_service"
 
 class ExpensesController < ApplicationController
     # Main page - shows current month expenses and adds up the total
     def index
         if user_signed_in?
             @expenses = current_user.expenses.current_month.order(date: :desc)
+            
+            # Get monthly report data
+            first_visit_detector = FirstVisitDetectorService.new(current_user)
+            @should_show_monthly_report = first_visit_detector.should_show_monthly_report?
+            @report_month = first_visit_detector.report_month_name
+            
+            if @should_show_monthly_report
+                spending_service = MonthlySpendingService.new(current_user)
+                @monthly_comparison = spending_service.monthly_comparison
+            end
+            
+            # Update visit date after checking if we should show the report
+            @is_first_visit = first_visit_detector.update_visit_date!
         else
             session[:guest_expenses] ||= []
             @expenses = session[:guest_expenses].map { |e| OpenStruct.new(e) }

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,25 @@
+class ReportsController < ApplicationController
+  before_action :authenticate_user!
+
+  # GET /reports/monthly_comparison
+  def monthly_comparison
+    # Check if this is first visit of the month
+    first_visit_detector = FirstVisitDetectorService.new(current_user)
+    is_first_visit = first_visit_detector.update_visit_date!
+    should_show_report = first_visit_detector.should_show_monthly_report?
+    
+    # Get monthly comparison data
+    spending_service = MonthlySpendingService.new(current_user)
+    comparison_data = spending_service.monthly_comparison
+    
+    render json: {
+      success: true,
+      data: {
+        comparison: comparison_data,
+        first_visit_of_month: is_first_visit,
+        should_show_monthly_report: should_show_report,
+        report_month: first_visit_detector.report_month_name
+      }
+    }
+  end
+end 

--- a/app/helpers/expenses_helper.rb
+++ b/app/helpers/expenses_helper.rb
@@ -1,2 +1,71 @@
 module ExpensesHelper
+  # Category emoji mapping
+  CATEGORY_EMOJIS = {
+    "Food & Dining" => "🍚",
+    "Beverage/Drink" => "🥤",
+    "Transportation" => "🚗",
+    "Shopping" => "🛍",
+    "Entertainment" => "🎬",
+    "Healthcare" => "🏥",
+    "Utilities" => "💡",
+    "Housing" => "🏠",
+    "Education" => "📚",
+    "Travel" => "✈️",
+    "Other" => "💸"
+  }.freeze
+
+  # Format currency amount
+  def format_currency(amount)
+    "¥#{number_with_delimiter(amount.to_i)}"
+  end
+
+  # Format percentage change
+  def format_percentage_change(percentage)
+    return "0%" if percentage.zero?
+    
+    direction = percentage > 0 ? "+" : ""
+    "#{direction}#{percentage}%"
+  end
+
+  # Get emoji for category
+  def category_emoji(category)
+    CATEGORY_EMOJIS[category] || "💸"
+  end
+
+  # Format a single category line for the report
+  def format_category_line(category, data)
+    emoji = category_emoji(category)
+    amount = format_currency(data[:last_month])
+    change = format_percentage_change(data[:change_percentage])
+    previous_month = data[:past_past_month]
+    
+    "#{emoji} #{category}: #{amount} (#{change} from #{previous_month})"
+  end
+
+  # Generate the full monthly report text
+  def generate_monthly_report_text(comparison_data)
+    return "No data available" unless comparison_data && comparison_data[:categories]
+    
+    lines = []
+    lines << "#{comparison_data[:last_month]} Report Card"
+    lines << ""
+    
+    comparison_data[:categories].each do |category, data|
+      lines << format_category_line(category, data)
+    end
+    
+    lines.join("\n")
+  end
+
+  # Check if there's a significant change (more than 5%)
+  def significant_change?(percentage)
+    percentage.abs > 5
+  end
+
+  # Get CSS class for change direction
+  def change_direction_class(percentage)
+    return "text-success" if percentage > 0
+    return "text-danger" if percentage < 0
+    "text-muted"
+  end
 end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -4,6 +4,7 @@ class Expense < ApplicationRecord
   # Predefined categories for consistent categorization
   CATEGORIES = [
     "Food & Dining",
+    "Beverage/Drink",
     "Transportation",
     "Shopping",
     "Entertainment",

--- a/app/services/first_visit_detector_service.rb
+++ b/app/services/first_visit_detector_service.rb
@@ -1,0 +1,43 @@
+class FirstVisitDetectorService
+  def initialize(user)
+    @user = user
+  end
+
+  # Check if this is the first visit of the current month
+  def first_visit_of_month?
+    return true if @user.last_visit_date.nil?
+    
+    current_month = Date.current.beginning_of_month
+    last_visit_month = @user.last_visit_date.beginning_of_month
+    
+    current_month > last_visit_month
+  end
+
+  # Update the user's last visit date and return if it was first visit
+  def update_visit_date!
+    was_first_visit = first_visit_of_month?
+    
+    @user.update!(last_visit_date: Time.current)
+    
+    was_first_visit
+  end
+
+  # Get the month name for the report (the last completed month)
+  def report_month_name
+    1.month.ago.strftime("%B")
+  end
+
+  # Check if user should see monthly report
+  def should_show_monthly_report?
+    first_visit_of_month? && has_expenses_in_last_month?
+  end
+
+  private
+
+  def has_expenses_in_last_month?
+    last_month_start = 1.month.ago.beginning_of_month
+    last_month_end = 1.month.ago.end_of_month
+    
+    @user.expenses.where(date: last_month_start..last_month_end).exists?
+  end
+end 

--- a/app/services/monthly_spending_service.rb
+++ b/app/services/monthly_spending_service.rb
@@ -1,0 +1,76 @@
+class MonthlySpendingService
+  def initialize(user)
+    @user = user
+  end
+
+  # Main method to get monthly comparison data (rolling comparison)
+  def monthly_comparison
+    last_month_data = get_month_data(1.month.ago)
+    past_past_month_data = get_month_data(2.months.ago)
+    
+    build_comparison(last_month_data, past_past_month_data)
+  end
+
+  # Get data for a specific month
+  def get_month_data(date)
+    month_start = date.beginning_of_month
+    month_end = date.end_of_month
+    
+    expenses = @user.expenses.where(date: month_start..month_end)
+    
+    {
+      month: date.strftime("%B"),
+      year: date.year,
+      total: expenses.sum(:price),
+      by_category: expenses.group(:category).sum(:price),
+      category_percentages: calculate_category_percentages(expenses)
+    }
+  end
+
+  # Build comparison hash with changes (last month vs past past month)
+  def build_comparison(last_month, past_past_month)
+    all_categories = (last_month[:by_category].keys + past_past_month[:by_category].keys).uniq
+    
+    comparison = {}
+    
+    all_categories.each do |category|
+      last_month_amount = last_month[:by_category][category] || 0
+      past_past_month_amount = past_past_month[:by_category][category] || 0
+      
+      change_percentage = calculate_change_percentage(past_past_month_amount, last_month_amount)
+      
+      comparison[category] = {
+        last_month: last_month_amount,
+        past_past_month: past_past_month_amount,
+        change_percentage: change_percentage,
+        change_direction: change_percentage >= 0 ? '+' : '-'
+      }
+    end
+    
+    {
+      last_month: last_month[:month],
+      past_past_month: past_past_month[:month],
+      last_month_total: last_month[:total],
+      past_past_month_total: past_past_month[:total],
+      total_change_percentage: calculate_change_percentage(past_past_month[:total], last_month[:total]),
+      categories: comparison
+    }
+  end
+
+  private
+
+  def calculate_category_percentages(expenses)
+    total = expenses.sum(:price)
+    return {} if total.zero?
+    
+    expenses.group(:category).sum(:price).transform_values do |amount|
+      (amount / total.to_f * 100).round(1)
+    end
+  end
+
+  def calculate_change_percentage(previous, current)
+    return 0 if previous.zero?
+    
+    ((current - previous) / previous.to_f * 100).round(1)
+  end
+end 

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -12,6 +12,51 @@
     <div class="amount">¥<%= number_with_delimiter(@total_price) %></div>
   </div>
 
+  <!-- Monthly Report Modal - shown only on first visit of the month -->
+  <% if user_signed_in? && @should_show_monthly_report && @monthly_comparison %>
+    <div id="monthly-report-modal" class="modal-overlay">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>📊 <%= @report_month %> Report Card</h3>
+          <button class="modal-close" onclick="closeMonthlyReport()">
+            <span class="close-icon">×</span>
+            <span class="close-text">dismiss</span>
+          </button>
+        </div>
+        
+        <div class="modal-body">
+          <% if @monthly_comparison[:categories].any? %>
+            <div class="report-categories">
+              <% @monthly_comparison[:categories].each do |category, data| %>
+                <div class="report-category-item">
+                  <span class="category-emoji"><%= category_emoji(category) %></span>
+                  <span class="category-name"><%= category %></span>
+                  <span class="category-amount"><%= format_currency(data[:last_month]) %></span>
+                  <span class="category-change <%= change_direction_class(data[:change_percentage]) %>">
+                    (<%= format_percentage_change(data[:change_percentage]) %> from <%= @monthly_comparison[:past_past_month] %>)
+                  </span>
+                </div>
+              <% end %>
+            </div>
+            
+            <div class="report-summary">
+              <div class="summary-total">
+                <strong>Total: <%= format_currency(@monthly_comparison[:last_month_total]) %></strong>
+                <span class="summary-change <%= change_direction_class(@monthly_comparison[:total_change_percentage]) %>">
+                  (<%= format_percentage_change(@monthly_comparison[:total_change_percentage]) %> from <%= @monthly_comparison[:past_past_month] %>)
+                </span>
+              </div>
+            </div>
+          <% else %>
+            <div class="no-data-message">
+              <p>No expenses to compare for <%= @report_month %></p>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
   <!-- Category breakdown with graph -->
   <% if @category_totals.any? %>
     <div class="category-overview fade-in">
@@ -225,4 +270,31 @@ document.addEventListener('DOMContentLoaded', () => {
     element.style.animationDelay = `${index * 0.1}s`;
   });
 });
+
+// Close the monthly report modal
+function closeMonthlyReport() {
+  const modal = document.getElementById('monthly-report-modal');
+  if (modal) {
+    modal.style.animation = 'fadeOut 0.3s ease-out';
+    setTimeout(() => {
+      modal.remove();
+    }, 300);
+  }
+}
+
+// Add fadeOut animation for modal closing
+const style = document.createElement('style');
+style.textContent = `
+  @keyframes fadeOut {
+    from {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(-20px) scale(0.95);
+    }
+  }
+`;
+document.head.appendChild(style);
 </script>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,9 @@ module ExpenseTrackerRails
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # Add services directory to autoload paths
+    config.autoload_paths << Rails.root.join("app", "services")
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
   # A simple page to check if the website is working
   get "up" => "rails/health#show", as: :rails_health_check
 
+  # Reports API
+  get "reports/monthly_comparison", to: "reports#monthly_comparison", as: :monthly_comparison_report
+
   # Special routes for editing and deleting many expenses at once
   # These must come BEFORE the normal routes so they work properly
   # - Shows the page where you can edit several expenses

--- a/db/migrate/20250706030735_add_last_visit_date_to_users.rb
+++ b/db/migrate/20250706030735_add_last_visit_date_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastVisitDateToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :last_visit_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_02_070142) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_06_030735) do
+  create_schema "auth"
+  create_schema "extensions"
+  create_schema "graphql"
+  create_schema "graphql_public"
+  create_schema "pgbouncer"
+  create_schema "realtime"
+  create_schema "storage"
+  create_schema "vault"
+
   # These are extensions that must be enabled in order to support this database
+  enable_extension "extensions.pg_stat_statements"
+  enable_extension "extensions.pgcrypto"
+  enable_extension "extensions.uuid-ossp"
+  enable_extension "graphql.pg_graphql"
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "vault.supabase_vault"
 
   create_table "expenses", force: :cascade do |t|
     t.date "date"
@@ -34,6 +48,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_02_070142) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.datetime "last_visit_date"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
### **What's New:**

- Popup modal that appears on first visit of each month
- Monthly spending comparison between last completed month and the month before that
- Category breakdown with percentage changes and emojis
- Dismissible interface with "× dismiss" button

### **Key Features:**

- Shows spending trends by category (e.g., "🛍️ Shopping: ¥8,000 (+60.0% from May)")
- Only displays on first visit of the month to avoid spam
- Responsive design that works on mobile and desktop
- Smooth animations with fade-in/out effects

### **Technical Implementation:**

- MonthlySpendingService - Calculates spending comparisons (last month vs past-past month)
- FirstVisitDetectorService - Manages when to show the report
- ReportsController - JSON API endpoint for monthly data
- Modal styling with backdrop blur and modern UI

### **New Category:**

- Added "Beverage/Drink" category with 🥤 emoji

### **📸 Screenshots**
![Screenshot_2025-07-06_at_13 01 47](https://github.com/user-attachments/assets/370929db-c9a9-4805-9085-43873a69ad75)
