### PR TITLE
Allow mobile users to choose between camera and gallery for receipt upload

### DIFF
--- a/app/views/receipt_scans/new.html.erb
+++ b/app/views/receipt_scans/new.html.erb
@@ -2,7 +2,7 @@
   <!-- Header section matching the main app style -->
   <div class="header fade-in">
     <h1>🧾 Scan Receipt</h1>
-    <p>Upload or take a photo of your receipt. We'll extract the details for you!</p>
+    <p>Take a photo or choose from your gallery. We'll extract the details for you!</p>
   </div>
 
   <!-- Upload card with consistent styling -->
@@ -13,7 +13,6 @@
         <div class="receipt-upload-area" style="margin-bottom: 1.5rem;">
           <%= form.file_field :image, 
               accept: 'image/*', 
-              capture: 'environment', 
               required: true %>
         </div>
         <div class="action-bar" style="justify-content: center;">


### PR DESCRIPTION
Completed Issue #22 

## What's Changed
- Removed `capture: 'environment'` attribute from file input
- Updated description text to reflect new options
- Mobile users can now choose between taking a photo or selecting from gallery

## Before
- Mobile users were forced to use camera only
- Limited user choice and flexibility

## After  
- Mobile users see native file picker with both options:
  - 📷 Camera - Take a new photo
  - 🖼️ Photo Library - Choose from existing photos
- Better user experience on mobile devices