### PR TITLE
fix: Edit Mode button height inconsistency

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -326,6 +326,27 @@ body {
   cursor: pointer;
   transition: all 0.2s ease;
   box-shadow: var(--shadow);
+  /* Ensure consistent sizing between button and anchor elements */
+  box-sizing: border-box;
+  min-height: 44px;
+  line-height: 1.2;
+}
+
+/* Override any browser defaults for button elements */
+button.btn {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 1.2;
+  height: auto;
+  vertical-align: baseline;
+  /* Force the same height calculation as anchor elements */
+  min-height: unset;
+  height: fit-content;
+  /* Remove any default button styling that affects height */
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
 }
 
 .btn-primary {
@@ -350,6 +371,8 @@ body {
   box-shadow: var(--shadow-lg);
 }
 
+
+
 .btn-danger {
   background-color: var(--danger-color);
   color: white;
@@ -371,6 +394,8 @@ body {
   transform: translateY(-1px);
   box-shadow: var(--shadow-lg);
 }
+
+
 
 /* Expense List */
 .expense-list {


### PR DESCRIPTION
Completed Issue #39 

## Problem
The Edit Mode button had inconsistent height compared to other buttons (Add Expense, Scan Receipt) despite using the same CSS classes.
## Root Cause
Browser default styling differences between `<button>` and `<a>` elements. Even with identical CSS classes,` <button> `elements have built-in browser styling that affects their height calculation, while `<a>` elements don't have the same default button-like properties.
## Solution 
Added CSS overrides to remove browser default button styling (appearance: none) and force consistent height calculation (height: fit-content) for button elements with the `.btn` class.
### Technical Details
The `<button>` element had different default line-height, height, and appearance properties compared to `<a>` elements, causing the height mismatch even with shared CSS classes.
This fix ensures all buttons maintain consistent sizing regardless of whether they're implemented as `<button>` or `<a>` elements.

## 📸 Screenshots
### Before
<img width="1549" height="800" alt="Screenshot 2025-07-14 at 14 20 48" src="https://github.com/user-attachments/assets/3b9b9f50-e10c-4f9d-bf02-47cea890b779" />

### After
<img width="1676" height="780" alt="Screenshot 2025-07-14 at 14 20 25" src="https://github.com/user-attachments/assets/8196e32f-7f7d-4089-ae6d-ae0597303a02" />
