### PR TITLE
fix: Remove keyboard navigation from carousel for readability and easier maintenance

### DIFF
--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -327,22 +327,5 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   });
-  
-  // Keyboard navigation
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-      const activeDot = document.querySelector('.carousel-dot.active');
-      const currentIndex = Array.from(carouselDots).indexOf(activeDot);
-      
-      let newIndex;
-      if (e.key === 'ArrowLeft') {
-        newIndex = currentIndex > 0 ? currentIndex - 1 : carouselDots.length - 1;
-      } else {
-        newIndex = currentIndex < carouselDots.length - 1 ? currentIndex + 1 : 0;
-      }
-      
-      carouselDots[newIndex].click();
-    }
-  });
 });
 </script>


### PR DESCRIPTION
# Problem:
The carousel’s keyboard navigation code made the script harder to read and maintain.
# Solution:
Removed the keyboard navigation logic to simplify the code and make future updates easier.